### PR TITLE
feat: Support List<T> field

### DIFF
--- a/Runtime/FindAssetsAttribute.cs
+++ b/Runtime/FindAssetsAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -13,7 +13,7 @@ namespace Kogane
     /// <summary>
     /// AssetDatabase.FindAssets を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class FindAssetsAttribute
         : Attribute,
           IGetComponentAttribute
@@ -27,20 +27,20 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
             var guid = AssetDatabase
-                    .FindAssets( $"t:{fieldInfo.FieldType.Name}" )
+                    .FindAssets($"t:{fieldInfo.FieldType.Name}")
                     .FirstOrDefault()
                 ;
 
-            if ( string.IsNullOrWhiteSpace( guid ) ) return;
+            if (string.IsNullOrWhiteSpace(guid)) return;
 
-            var assetPath = AssetDatabase.GUIDToAssetPath( guid );
-            var asset     = AssetDatabase.LoadAssetAtPath<Object>( assetPath );
+            var assetPath = AssetDatabase.GUIDToAssetPath(guid);
+            var asset = AssetDatabase.LoadAssetAtPath<Object>(assetPath);
 
             serializedProperty.objectReferenceValue = asset;
         }

--- a/Runtime/FindAttribute.cs
+++ b/Runtime/FindAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -11,7 +11,7 @@ namespace Kogane
     /// <summary>
     /// GameObject.Find を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class FindAttribute
         : Attribute,
           IGetComponentAttribute
@@ -27,7 +27,7 @@ namespace Kogane
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public FindAttribute( string name )
+        public FindAttribute(string name)
         {
             m_name = name;
         }
@@ -38,12 +38,17 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
-            serializedProperty.objectReferenceValue = GameObject.Find( m_name );
+            if (serializedProperty.isArray)
+            {
+                return;
+            }
+
+            serializedProperty.objectReferenceValue = GameObject.Find(m_name);
         }
 #endif
     }

--- a/Runtime/FindChildAttribute.cs
+++ b/Runtime/FindChildAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -11,7 +11,7 @@ namespace Kogane
     /// <summary>
     /// Transform.Find を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class FindChildAttribute
         : Attribute,
           IGetComponentAttribute
@@ -27,7 +27,7 @@ namespace Kogane
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public FindChildAttribute( string name )
+        public FindChildAttribute(string name)
         {
             m_name = name;
         }
@@ -38,12 +38,17 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
-            serializedProperty.objectReferenceValue = monoBehaviour.transform.Find( m_name );
+            if (serializedProperty.isArray)
+            {
+                return;
+            }
+
+            serializedProperty.objectReferenceValue = monoBehaviour.transform.Find(m_name);
         }
 #endif
     }

--- a/Runtime/FindObjectOfTypeAttribute.cs
+++ b/Runtime/FindObjectOfTypeAttribute.cs
@@ -54,6 +54,11 @@ namespace Kogane
             SerializedProperty serializedProperty
         )
         {
+            if (serializedProperty.isArray)
+            {
+                return;
+            }
+
             var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
             var fieldType = fieldInfo.FieldType;
 

--- a/Runtime/FindObjectOfTypeAttribute.cs
+++ b/Runtime/FindObjectOfTypeAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -13,7 +13,7 @@ namespace Kogane
     /// <summary>
     /// Object.FindObjectOfType を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class FindObjectOfTypeAttribute
         : Attribute,
           IGetComponentAttribute
@@ -30,14 +30,14 @@ namespace Kogane
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public FindObjectOfTypeAttribute() : this( true )
+        public FindObjectOfTypeAttribute() : this(true)
         {
         }
 
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public FindObjectOfTypeAttribute( bool includeInactive )
+        public FindObjectOfTypeAttribute(bool includeInactive)
         {
             m_includeInactive = includeInactive;
         }
@@ -49,17 +49,17 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
             var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
-            var fieldType   = fieldInfo.FieldType;
+            var fieldType = fieldInfo.FieldType;
 
-            serializedProperty.objectReferenceValue = prefabStage != null && prefabStage.IsPartOfPrefabContents( monoBehaviour.gameObject )
-                    ? prefabStage.FindComponentOfType( fieldType )
-                    : Object.FindObjectOfType( fieldType, m_includeInactive )
+            serializedProperty.objectReferenceValue = prefabStage != null && prefabStage.IsPartOfPrefabContents(monoBehaviour.gameObject)
+                    ? prefabStage.scene.GetRootGameObjects()[0].GetComponentInChildren(fieldType, m_includeInactive)
+                    : Object.FindObjectOfType(fieldType, m_includeInactive)
                 ;
         }
 #endif

--- a/Runtime/FindObjectsOfTypeAttribute.cs
+++ b/Runtime/FindObjectsOfTypeAttribute.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using UnityEngine;
+using System.Linq;
 #if UNITY_EDITOR
 using UnityEditor;
 using UnityEditor.SceneManagement;
@@ -55,7 +56,7 @@ namespace Kogane
         {
             var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
             var fieldType = fieldInfo.FieldType;
-            var elementType = fieldType.GetElementType();
+            var elementType = fieldType.GetElementType() ?? fieldType.GetGenericArguments().SingleOrDefault();
 
             var components = prefabStage != null
                     ? prefabStage.scene.GetRootGameObjects()[0].GetComponentsInChildren(elementType, m_includeInactive)

--- a/Runtime/FindObjectsOfTypeAttribute.cs
+++ b/Runtime/FindObjectsOfTypeAttribute.cs
@@ -54,6 +54,11 @@ namespace Kogane
             SerializedProperty serializedProperty
         )
         {
+            if (!serializedProperty.isArray)
+            {
+                return;
+            }
+
             var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
             var fieldType = fieldInfo.FieldType;
             var elementType = fieldType.GetElementType() ?? fieldType.GetGenericArguments().SingleOrDefault();

--- a/Runtime/FindObjectsOfTypeAttribute.cs
+++ b/Runtime/FindObjectsOfTypeAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -12,7 +12,7 @@ namespace Kogane
     /// <summary>
     /// Object.FindObjectsOfType を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class FindObjectsOfTypeAttribute
         : Attribute,
           IGetComponentAttribute
@@ -29,14 +29,14 @@ namespace Kogane
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public FindObjectsOfTypeAttribute() : this( true )
+        public FindObjectsOfTypeAttribute() : this(true)
         {
         }
 
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public FindObjectsOfTypeAttribute( bool includeInactive )
+        public FindObjectsOfTypeAttribute(bool includeInactive)
         {
             m_includeInactive = includeInactive;
         }
@@ -48,28 +48,28 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
             var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
-            var fieldType   = fieldInfo.FieldType;
+            var fieldType = fieldInfo.FieldType;
             var elementType = fieldType.GetElementType();
 
             var components = prefabStage != null
-                    ? prefabStage.FindComponentsOfType( elementType )
-                    : UnityEngine.Object.FindObjectsOfType( elementType, m_includeInactive )
+                    ? prefabStage.scene.GetRootGameObjects()[0].GetComponentsInChildren(elementType, m_includeInactive)
+                    : UnityEngine.Object.FindObjectsOfType(elementType, m_includeInactive)
                 ;
 
             var componentCount = components.Length;
 
             serializedProperty.arraySize = componentCount;
 
-            for ( var i = 0; i < componentCount; i++ )
+            for (var i = 0; i < componentCount; i++)
             {
-                var element   = serializedProperty.GetArrayElementAtIndex( i );
-                var component = components[ i ];
+                var element = serializedProperty.GetArrayElementAtIndex(i);
+                var component = components[i];
 
                 element.objectReferenceValue = component;
             }

--- a/Runtime/FindWithTagAttribute.cs
+++ b/Runtime/FindWithTagAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -11,7 +11,7 @@ namespace Kogane
     /// <summary>
     /// GameObject.FindWithTag を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class FindWithTagAttribute
         : Attribute,
           IGetComponentAttribute
@@ -27,7 +27,7 @@ namespace Kogane
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public FindWithTagAttribute( string tag )
+        public FindWithTagAttribute(string tag)
         {
             m_tag = tag;
         }
@@ -38,12 +38,17 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
-            serializedProperty.objectReferenceValue = GameObject.FindWithTag( m_tag );
+            if (serializedProperty.isArray)
+            {
+                return;
+            }
+
+            serializedProperty.objectReferenceValue = GameObject.FindWithTag(m_tag);
         }
 #endif
     }

--- a/Runtime/GetComponentAttribute.cs
+++ b/Runtime/GetComponentAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -11,7 +11,7 @@ namespace Kogane
     /// <summary>
     /// GetComponent を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class GetComponentAttribute
         : Attribute,
           IGetComponentAttribute
@@ -25,13 +25,18 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
+            if (serializedProperty.isArray)
+            {
+                return;
+            }
+
             serializedProperty.objectReferenceValue =
-                monoBehaviour.GetComponent( fieldInfo.FieldType );
+                monoBehaviour.GetComponent(fieldInfo.FieldType);
         }
 #endif
     }

--- a/Runtime/GetComponentInChildrenAttribute.cs
+++ b/Runtime/GetComponentInChildrenAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -11,7 +11,7 @@ namespace Kogane
     /// <summary>
     /// GetComponentInChildren を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class GetComponentInChildrenAttribute
         : Attribute,
           IGetComponentAttribute
@@ -27,14 +27,14 @@ namespace Kogane
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentInChildrenAttribute() : this( true )
+        public GetComponentInChildrenAttribute() : this(true)
         {
         }
 
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentInChildrenAttribute( bool includeInactive )
+        public GetComponentInChildrenAttribute(bool includeInactive)
         {
             m_includeInactive = includeInactive;
         }
@@ -45,13 +45,18 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
+            if (serializedProperty.isArray)
+            {
+                return;
+            }
+
             serializedProperty.objectReferenceValue =
-                monoBehaviour.GetComponentInChildren( fieldInfo.FieldType, m_includeInactive );
+                monoBehaviour.GetComponentInChildren(fieldInfo.FieldType, m_includeInactive);
         }
 #endif
     }

--- a/Runtime/GetComponentInChildrenOnlyAttribute.cs
+++ b/Runtime/GetComponentInChildrenOnlyAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -12,7 +12,7 @@ namespace Kogane
     /// <summary>
     /// 自分自身は対象にしない GetComponentInChildren を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class GetComponentInChildrenOnlyAttribute
         : Attribute,
           IGetComponentAttribute
@@ -28,14 +28,14 @@ namespace Kogane
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentInChildrenOnlyAttribute() : this( true )
+        public GetComponentInChildrenOnlyAttribute() : this(true)
         {
         }
 
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentInChildrenOnlyAttribute( bool includeInactive )
+        public GetComponentInChildrenOnlyAttribute(bool includeInactive)
         {
             m_includeInactive = includeInactive;
         }
@@ -46,14 +46,19 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
+            if (serializedProperty.isArray)
+            {
+                return;
+            }
+
             serializedProperty.objectReferenceValue = monoBehaviour
-                    .GetComponentsInChildren( fieldInfo.FieldType, m_includeInactive )
-                    .FirstOrDefault( x => x.gameObject != monoBehaviour.gameObject )
+                    .GetComponentsInChildren(fieldInfo.FieldType, m_includeInactive)
+                    .FirstOrDefault(x => x.gameObject != monoBehaviour.gameObject)
                 ;
         }
 #endif

--- a/Runtime/GetComponentInParentAttribute.cs
+++ b/Runtime/GetComponentInParentAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -11,7 +11,7 @@ namespace Kogane
     /// <summary>
     /// GetComponentInParent を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class GetComponentInParentAttribute
         : Attribute,
           IGetComponentAttribute
@@ -25,13 +25,18 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
+            if (serializedProperty.isArray)
+            {
+                return;
+            }
+
             serializedProperty.objectReferenceValue =
-                monoBehaviour.GetComponentInParent( fieldInfo.FieldType );
+                monoBehaviour.GetComponentInParent(fieldInfo.FieldType);
         }
 #endif
     }

--- a/Runtime/GetComponentInParentOnlyAttribute.cs
+++ b/Runtime/GetComponentInParentOnlyAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -12,7 +12,7 @@ namespace Kogane
     /// <summary>
     /// 自分自身は対象にしない GetComponentInParent を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class GetComponentInParentOnlyAttribute
         : Attribute,
           IGetComponentAttribute
@@ -28,14 +28,14 @@ namespace Kogane
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentInParentOnlyAttribute() : this( true )
+        public GetComponentInParentOnlyAttribute() : this(true)
         {
         }
 
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentInParentOnlyAttribute( bool includeInactive )
+        public GetComponentInParentOnlyAttribute(bool includeInactive)
         {
             m_includeInactive = includeInactive;
         }
@@ -46,14 +46,19 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
+            if (serializedProperty.isArray)
+            {
+                return;
+            }
+
             serializedProperty.objectReferenceValue = monoBehaviour
-                    .GetComponentsInParent( fieldInfo.FieldType, m_includeInactive )
-                    .FirstOrDefault( x => x.gameObject != monoBehaviour.gameObject )
+                    .GetComponentsInParent(fieldInfo.FieldType, m_includeInactive)
+                    .FirstOrDefault(x => x.gameObject != monoBehaviour.gameObject)
                 ;
         }
 #endif

--- a/Runtime/GetComponentsAttribute.cs
+++ b/Runtime/GetComponentsAttribute.cs
@@ -31,8 +31,14 @@ namespace Kogane
             SerializedProperty serializedProperty
         )
         {
+            if (!serializedProperty.isArray)
+            {
+                return;
+            }
+
             var fieldType = fieldInfo.FieldType;
             var elementType = fieldType.GetElementType() ?? fieldType.GetGenericArguments().SingleOrDefault();
+
             var components = monoBehaviour.GetComponents(elementType);
             var componentCount = components.Length;
 

--- a/Runtime/GetComponentsAttribute.cs
+++ b/Runtime/GetComponentsAttribute.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
+using System.Linq;
 #if UNITY_EDITOR
 using UnityEditor;
 
@@ -11,7 +12,7 @@ namespace Kogane
     /// <summary>
     /// GetComponents を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class GetComponentsAttribute
         : Attribute,
           IGetComponentAttribute
@@ -25,22 +26,22 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
-            var fieldType      = fieldInfo.FieldType;
-            var elementType    = fieldType.GetElementType();
-            var components     = monoBehaviour.GetComponents( elementType );
+            var fieldType = fieldInfo.FieldType;
+            var elementType = fieldType.GetElementType() ?? fieldType.GetGenericArguments().SingleOrDefault();
+            var components = monoBehaviour.GetComponents(elementType);
             var componentCount = components.Length;
 
             serializedProperty.arraySize = componentCount;
 
-            for ( var i = 0; i < componentCount; i++ )
+            for (var i = 0; i < componentCount; i++)
             {
-                var element   = serializedProperty.GetArrayElementAtIndex( i );
-                var component = components[ i ];
+                var element = serializedProperty.GetArrayElementAtIndex(i);
+                var component = components[i];
 
                 element.objectReferenceValue = component;
             }

--- a/Runtime/GetComponentsInChildrenAttribute.cs
+++ b/Runtime/GetComponentsInChildrenAttribute.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
+using System.Linq;
 #if UNITY_EDITOR
 using UnityEditor;
 
@@ -11,7 +12,7 @@ namespace Kogane
     /// <summary>
     /// GetComponentsInChildren を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class GetComponentsInChildrenAttribute
         : Attribute,
           IGetComponentAttribute
@@ -27,14 +28,14 @@ namespace Kogane
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentsInChildrenAttribute() : this( true )
+        public GetComponentsInChildrenAttribute() : this(true)
         {
         }
 
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentsInChildrenAttribute( bool includeInactive )
+        public GetComponentsInChildrenAttribute(bool includeInactive)
         {
             m_includeInactive = includeInactive;
         }
@@ -45,27 +46,27 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
-            var fieldType   = fieldInfo.FieldType;
-            var elementType = fieldType.GetElementType();
+            var fieldType = fieldInfo.FieldType;
+            var elementType = fieldType.GetElementType() ?? fieldType.GetGenericArguments().SingleOrDefault();
 
             // 配列やリストではないフィールドに GetComponentsInChildrenAttribute を付けると
             // elementType が null になる
-            if ( elementType == null ) return;
+            if (elementType == null) return;
 
-            var components     = monoBehaviour.GetComponentsInChildren( elementType, m_includeInactive );
+            var components = monoBehaviour.GetComponentsInChildren(elementType, m_includeInactive);
             var componentCount = components.Length;
 
             serializedProperty.arraySize = componentCount;
 
-            for ( var i = 0; i < componentCount; i++ )
+            for (var i = 0; i < componentCount; i++)
             {
-                var element   = serializedProperty.GetArrayElementAtIndex( i );
-                var component = components[ i ];
+                var element = serializedProperty.GetArrayElementAtIndex(i);
+                var component = components[i];
 
                 element.objectReferenceValue = component;
             }

--- a/Runtime/GetComponentsInChildrenAttribute.cs
+++ b/Runtime/GetComponentsInChildrenAttribute.cs
@@ -51,12 +51,13 @@ namespace Kogane
             SerializedProperty serializedProperty
         )
         {
+            if (!serializedProperty.isArray)
+            {
+                return;
+            }
+
             var fieldType = fieldInfo.FieldType;
             var elementType = fieldType.GetElementType() ?? fieldType.GetGenericArguments().SingleOrDefault();
-
-            // 配列やリストではないフィールドに GetComponentsInChildrenAttribute を付けると
-            // elementType が null になる
-            if (elementType == null) return;
 
             var components = monoBehaviour.GetComponentsInChildren(elementType, m_includeInactive);
             var componentCount = components.Length;

--- a/Runtime/GetComponentsInChildrenOnlyAttribute.cs
+++ b/Runtime/GetComponentsInChildrenOnlyAttribute.cs
@@ -51,6 +51,11 @@ namespace Kogane
             SerializedProperty serializedProperty
         )
         {
+            if (!serializedProperty.isArray)
+            {
+                return;
+            }
+
             var fieldType = fieldInfo.FieldType;
             var elementType = fieldType.GetElementType() ?? fieldType.GetGenericArguments().SingleOrDefault();
 

--- a/Runtime/GetComponentsInChildrenOnlyAttribute.cs
+++ b/Runtime/GetComponentsInChildrenOnlyAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -12,7 +12,7 @@ namespace Kogane
     /// <summary>
     /// 自分自身は対象にしない GetComponentsInChildren を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class GetComponentsInChildrenOnlyAttribute
         : Attribute,
           IGetComponentAttribute
@@ -28,14 +28,14 @@ namespace Kogane
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentsInChildrenOnlyAttribute() : this( true )
+        public GetComponentsInChildrenOnlyAttribute() : this(true)
         {
         }
 
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentsInChildrenOnlyAttribute( bool includeInactive )
+        public GetComponentsInChildrenOnlyAttribute(bool includeInactive)
         {
             m_includeInactive = includeInactive;
         }
@@ -46,17 +46,17 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
-            var fieldType   = fieldInfo.FieldType;
-            var elementType = fieldType.GetElementType();
+            var fieldType = fieldInfo.FieldType;
+            var elementType = fieldType.GetElementType() ?? fieldType.GetGenericArguments().SingleOrDefault();
 
             var components = monoBehaviour
-                    .GetComponentsInChildren( elementType, m_includeInactive )
-                    .Where( x => x.gameObject != monoBehaviour.gameObject )
+                    .GetComponentsInChildren(elementType, m_includeInactive)
+                    .Where(x => x.gameObject != monoBehaviour.gameObject)
                     .ToArray()
                 ;
 
@@ -64,10 +64,10 @@ namespace Kogane
 
             serializedProperty.arraySize = componentCount;
 
-            for ( var i = 0; i < componentCount; i++ )
+            for (var i = 0; i < componentCount; i++)
             {
-                var element   = serializedProperty.GetArrayElementAtIndex( i );
-                var component = components[ i ];
+                var element = serializedProperty.GetArrayElementAtIndex(i);
+                var component = components[i];
 
                 element.objectReferenceValue = component;
             }

--- a/Runtime/GetComponentsInParentAttribute.cs
+++ b/Runtime/GetComponentsInParentAttribute.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
+using System.Linq;
 #if UNITY_EDITOR
 using UnityEditor;
 
@@ -11,7 +12,7 @@ namespace Kogane
     /// <summary>
     /// GetComponentsInParent を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class GetComponentsInParentAttribute
         : Attribute,
           IGetComponentAttribute
@@ -27,14 +28,14 @@ namespace Kogane
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentsInParentAttribute() : this( true )
+        public GetComponentsInParentAttribute() : this(true)
         {
         }
 
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentsInParentAttribute( bool includeInactive )
+        public GetComponentsInParentAttribute(bool includeInactive)
         {
             m_includeInactive = includeInactive;
         }
@@ -45,22 +46,22 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
-            var fieldType      = fieldInfo.FieldType;
-            var elementType    = fieldType.GetElementType();
-            var components     = monoBehaviour.GetComponentsInParent( elementType, m_includeInactive );
+            var fieldType = fieldInfo.FieldType;
+            var elementType = fieldType.GetElementType() ?? fieldType.GetGenericArguments().SingleOrDefault();
+            var components = monoBehaviour.GetComponentsInParent(elementType, m_includeInactive);
             var componentCount = components.Length;
 
             serializedProperty.arraySize = componentCount;
 
-            for ( var i = 0; i < componentCount; i++ )
+            for (var i = 0; i < componentCount; i++)
             {
-                var element   = serializedProperty.GetArrayElementAtIndex( i );
-                var component = components[ i ];
+                var element = serializedProperty.GetArrayElementAtIndex(i);
+                var component = components[i];
 
                 element.objectReferenceValue = component;
             }

--- a/Runtime/GetComponentsInParentAttribute.cs
+++ b/Runtime/GetComponentsInParentAttribute.cs
@@ -51,8 +51,14 @@ namespace Kogane
             SerializedProperty serializedProperty
         )
         {
+            if (!serializedProperty.isArray)
+            {
+                return;
+            }
+
             var fieldType = fieldInfo.FieldType;
             var elementType = fieldType.GetElementType() ?? fieldType.GetGenericArguments().SingleOrDefault();
+
             var components = monoBehaviour.GetComponentsInParent(elementType, m_includeInactive);
             var componentCount = components.Length;
 

--- a/Runtime/GetComponentsInParentOnlyAttribute.cs
+++ b/Runtime/GetComponentsInParentOnlyAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -12,7 +12,7 @@ namespace Kogane
     /// <summary>
     /// 自分自身は対象にしない GetComponentsInParent を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class GetComponentsInParentOnlyAttribute
         : Attribute,
           IGetComponentAttribute
@@ -28,14 +28,14 @@ namespace Kogane
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentsInParentOnlyAttribute() : this( true )
+        public GetComponentsInParentOnlyAttribute() : this(true)
         {
         }
 
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public GetComponentsInParentOnlyAttribute( bool includeInactive )
+        public GetComponentsInParentOnlyAttribute(bool includeInactive)
         {
             m_includeInactive = includeInactive;
         }
@@ -46,17 +46,17 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
-            var fieldType   = fieldInfo.FieldType;
-            var elementType = fieldType.GetElementType();
+            var fieldType = fieldInfo.FieldType;
+            var elementType = fieldType.GetElementType() ?? fieldType.GetGenericArguments().SingleOrDefault();
 
             var components = monoBehaviour
-                    .GetComponentsInParent( elementType, m_includeInactive )
-                    .Where( x => x.gameObject != monoBehaviour.gameObject )
+                    .GetComponentsInParent(elementType, m_includeInactive)
+                    .Where(x => x.gameObject != monoBehaviour.gameObject)
                     .ToArray()
                 ;
 
@@ -64,10 +64,10 @@ namespace Kogane
 
             serializedProperty.arraySize = componentCount;
 
-            for ( var i = 0; i < componentCount; i++ )
+            for (var i = 0; i < componentCount; i++)
             {
-                var element   = serializedProperty.GetArrayElementAtIndex( i );
-                var component = components[ i ];
+                var element = serializedProperty.GetArrayElementAtIndex(i);
+                var component = components[i];
 
                 element.objectReferenceValue = component;
             }

--- a/Runtime/GetComponentsInParentOnlyAttribute.cs
+++ b/Runtime/GetComponentsInParentOnlyAttribute.cs
@@ -51,6 +51,11 @@ namespace Kogane
             SerializedProperty serializedProperty
         )
         {
+            if (!serializedProperty.isArray)
+            {
+                return;
+            }
+
             var fieldType = fieldInfo.FieldType;
             var elementType = fieldType.GetElementType() ?? fieldType.GetGenericArguments().SingleOrDefault();
 

--- a/Runtime/GetOrAddComponentAttribute.cs
+++ b/Runtime/GetOrAddComponentAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -11,7 +11,7 @@ namespace Kogane
     /// <summary>
     /// GetOrAddComponent を実行する Attribute
     /// </summary>
-    [AttributeUsage( AttributeTargets.Field )]
+    [AttributeUsage(AttributeTargets.Field)]
     public sealed class GetOrAddComponentAttribute
         : Attribute,
           IGetComponentAttribute
@@ -25,16 +25,21 @@ namespace Kogane
         /// </summary>
         public void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         )
         {
+            if (serializedProperty.isArray)
+            {
+                return;
+            }
+
             var fieldType = fieldInfo.FieldType;
 
-            if ( !monoBehaviour.TryGetComponent( fieldType, out var component ) )
+            if (!monoBehaviour.TryGetComponent(fieldType, out var component))
             {
-                component = monoBehaviour.gameObject.AddComponent( fieldType );
+                component = monoBehaviour.gameObject.AddComponent(fieldType);
             }
 
             serializedProperty.objectReferenceValue = component;

--- a/Runtime/IGetComponentAttribute.cs
+++ b/Runtime/IGetComponentAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -21,8 +21,8 @@ namespace Kogane
         /// </summary>
         void Inject
         (
-            MonoBehaviour      monoBehaviour,
-            FieldInfo          fieldInfo,
+            MonoBehaviour monoBehaviour,
+            FieldInfo fieldInfo,
             SerializedProperty serializedProperty
         );
 #endif


### PR DESCRIPTION
- fix: No overload for method 'FindComponentOfType' takes 1 arguments. (On Unity 2022.2.8f1)
- feat: Support List<T> field.
- add: Check "serializedProperty.isArray" before inject. (Avoid failed to get elementType of field)